### PR TITLE
chore: Update OpenGraph's title and description for each page

### DIFF
--- a/app/(main)/(routes)/(404)/not-found.tsx
+++ b/app/(main)/(routes)/(404)/not-found.tsx
@@ -1,5 +1,17 @@
+import { Metadata } from 'next';
 import { Header } from '~/components/header';
 import { InternalLink } from '~/components/ui/buttons';
+
+export const metadata: Metadata = {
+  title: '404 Error',
+  description:
+    "Oops! It looks like the page you're trying to access doesn't exist. Don't worry, you can explore other areas of CodeDevils to find what you're looking for. If you need assistance, feel free to contact us.",
+  openGraph: {
+    title: '404 Error',
+    description:
+      "Oops! It looks like the page you're trying to access doesn't exist. Don't worry, you can explore other areas of CodeDevils to find what you're looking for. If you need assistance, feel free to contact us.",
+  },
+};
 
 export default function NotFoundCatchAll() {
   return (

--- a/app/(main)/(routes)/about/page.tsx
+++ b/app/(main)/(routes)/about/page.tsx
@@ -10,9 +10,14 @@ import { IconLeaf, IconHammer, IconBrandAsana } from '@tabler/icons-react';
 import { officers, projectLeads } from '~/utils/staticdata';
 
 export const metadata: Metadata = {
-  title: 'About CodeDevils',
+  title: 'About Us',
   description:
     "Learn more about CodeDevils, including our history, mission, and leadership team. Discover the industry professionals who support our projects and how we're preparing members for successful careers in software development.",
+  openGraph: {
+    title: 'About Us',
+    description:
+      "Learn more about CodeDevils, including our history, mission, and leadership team. Discover the industry professionals who support our projects and how we're preparing members for successful careers in software development.",
+  },
 };
 
 const AboutPage: NextPage = () => {

--- a/app/(main)/(routes)/careers/page.tsx
+++ b/app/(main)/(routes)/careers/page.tsx
@@ -6,9 +6,14 @@ import { ExternalLink, InternalLink } from '~/components/ui/buttons';
 import { Hero, Section, SupportSection } from '~/components/ui/sections';
 
 export const metadata: Metadata = {
-  title: 'Careers at CodeDevils',
+  title: 'Careers',
   description:
     'Explore career opportunities at CodeDevils and learn what it takes to join our leadership team. Discover the values we look for and how you can contribute to our mission of empowering software developers.',
+  openGraph: {
+    title: 'Careers',
+    description:
+      'Explore career opportunities at CodeDevils and learn what it takes to join our leadership team. Discover the values we look for and how you can contribute to our mission of empowering software developers.',
+  },
 };
 
 const CareersPage: NextPage = () => {

--- a/app/(main)/(routes)/get-started/page.tsx
+++ b/app/(main)/(routes)/get-started/page.tsx
@@ -5,9 +5,14 @@ import { ExternalLink } from '~/components/ui/buttons';
 import { socialLinks } from '~/utils/staticdata';
 
 export const metadata: Metadata = {
-  title: 'Getting Started with CodeDevils',
+  title: 'Getting Started',
   description:
     'Learn how to join CodeDevils and become part of our vibrant software development community. Find out what steps to take, what to expect, and how you can start contributing to projects and improving your coding skills.',
+  openGraph: {
+    title: 'Getting Started',
+    description:
+      'Learn how to join CodeDevils and become part of our vibrant software development community. Find out what steps to take, what to expect, and how you can start contributing to projects and improving your coding skills.',
+  },
 };
 
 const getStarted: NextPage = () => {

--- a/app/(main)/(routes)/projects/page.tsx
+++ b/app/(main)/(routes)/projects/page.tsx
@@ -9,9 +9,14 @@ import { ExternalLink, InternalLink } from '~/components/ui/buttons';
 import { socialLinks } from '~/utils/staticdata';
 
 export const metadata: Metadata = {
-  title: "CodeDevils' Projects",
+  title: 'Projects',
   description:
     'Discover open source projects at CodeDevils and learn how to get involved. Collaborate with fellow developers, gain real-world experience, and make a meaningful impact through open source contributions.',
+  openGraph: {
+    title: 'Projects',
+    description:
+      'Discover open source projects at CodeDevils and learn how to get involved. Collaborate with fellow developers, gain real-world experience, and make a meaningful impact through open source contributions.',
+  },
 };
 
 const projectsPage: NextPage = () => {

--- a/app/(main)/(routes)/support/page.tsx
+++ b/app/(main)/(routes)/support/page.tsx
@@ -10,9 +10,14 @@ import AccordionItem from '~/components/accordionItem';
 import { socialLinks } from '~/utils/staticdata';
 
 export const metadata: Metadata = {
-  title: "CodeDevils' Support",
+  title: 'Support',
   description:
     'Need help with a technical issue or guidance on your software development journey? Visit the CodeDevils Support page for resources, FAQs, and expert assistance from our support team.',
+  openGraph: {
+    title: 'Support',
+    description:
+      'Need help with a technical issue or guidance on your software development journey? Visit the CodeDevils Support page for resources, FAQs, and expert assistance from our support team.',
+  },
 };
 
 const ContactPage: NextPage = () => {
@@ -84,9 +89,7 @@ const ContactPage: NextPage = () => {
               <path d='M9 16h6' />
             </svg>
             <Link
-              href='https://docs.codedevils.org'
-              target='_blank'
-              rel='noopener noreferrer'
+              href='https://docs.codedevils.io'
               className='text-xl hover:underline'
             >
               Project Documentation

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { type NextPage } from 'next';
+import type { NextPage, Metadata } from 'next';
 
 import { InfiniteLogoCarousel } from '~/components/infiniteLogoCarousel';
 import { Section, SupportSection } from '~/components/ui/sections';
@@ -7,6 +7,12 @@ import { ExternalLink, InternalLink } from '~/components/ui/buttons';
 
 import { socialLinks } from '~/utils/staticdata';
 import { Header } from '~/components/header';
+
+export const metadata: Metadata = {
+  title: 'CodeDevils',
+  description:
+    'Discover CodeDevils, a vibrant software development community at Arizona State University. Learn how we help members grow their coding skills and prepare for tech careers. Explore our programs, events, and resources.',
+};
 
 const HomePage: NextPage = () => {
   const { discord } = socialLinks;

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -5,7 +5,7 @@ export default function manifest(): MetadataRoute.Manifest {
     name: 'CodeDevils',
     short_name: 'CodeDevils',
     description:
-      'Discover CodeDevils, a vibrant software development community at Arizona State University. Learn how we help members grow their coding skills and prepare for tech careers.',
+      "Grow your software development skills with CodeDevils, Arizona State University's largest software development student organization. Learn, build, and network with us!",
     start_url: '/',
     display: 'standalone',
     background_color: '#ffffff',


### PR DESCRIPTION
Creates a custom title and description for preview links on each page to improve SEO. Additionally, updates the manifest file's description to match metadata description. Removes all references to "CodeDevils" in individual page's metadata titles as they are now unnecessary with the new metadata title template.