### PR TITLE
fix: update invalid discord invite link

### DIFF
--- a/utils/staticdata.ts
+++ b/utils/staticdata.ts
@@ -179,7 +179,7 @@ export const projectLeads = [
 ];
 
 export const socialLinks = {
-  discord: 'https://discord.gg/eevXKjVmm2',
+  discord: 'https://discord.gg/tHgJGawHPE',
   sundevilsync: 'https://asu.campuslabs.com/engage/organization/codedevils/',
   linkedin: 'https://www.linkedin.com/company/codedevils-official/',
   instagram: 'https://www.instagram.com/codedevils.asu/',


### PR DESCRIPTION
This patch replaces the invalid Discord invite link with a newly generated one.

> This is just a temporary patch. This does not replace PR #67, where we are using a custom Discord invite link.

