### PR TITLE
Update the link to official docs site in Navbar

### DIFF
--- a/app/(main)/(routes)/support/page.tsx
+++ b/app/(main)/(routes)/support/page.tsx
@@ -89,7 +89,7 @@ const ContactPage: NextPage = () => {
               <path d='M9 16h6' />
             </svg>
             <Link
-              href='https://docs.codedevils.io'
+              href='https://docs.codedevils.org'
               className='text-xl hover:underline'
             >
               Project Documentation

--- a/components/banner.tsx
+++ b/components/banner.tsx
@@ -8,7 +8,7 @@ const Banner = () => {
         <ul className="flex justify-start gap-4 text-maroon md:justify-end">
           <li>
             <Link
-              href="https://docs.codedevils.club"
+              href="https://docs.codedevils.org"
               className="hover:underline"
             >
               Docs

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -77,7 +77,7 @@ const Navbar = () => {
               <Dropdown setActive={setActive} active={active} item="Members">
                 <div className="flex flex-col space-y-4 text-sm">
                   <DropdownItem
-                    href="https://docs.codedevils.club"
+                    href="https://docs.codedevils.org"
                     onClick={() => setShowMobileNav(!showMobileNav)}
                   >
                     Documentation


### PR DESCRIPTION
The link to CodeDevils’ official documentation site has been updated to use the .org domain.